### PR TITLE
Stop adding statusCode

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,6 @@ exports.request = async function request (settings, originalJWT) {
         } else {
           // Consider these to be okay
           if (response) {
-            response.statusCode = response.statusCode || 500
             return response
           }
           if (requestObject.simple) {
@@ -149,7 +148,6 @@ exports.request = async function request (settings, originalJWT) {
     }
   }
   if (response) {
-    response.statusCode = response.statusCode || 500
     return response
   }
   if (requestObject.simple) {


### PR DESCRIPTION
As a result of L141 and L152 in https://github.com/byu-oit/byu-wso2-request/commit/ec73fd4cdffbf9e540b15d486279ea7226ca3645,
I now get bodies that have a statusCode property that I wasn't expecting, like:
```
{
  "metadata": {
    "validation_response": {
      "code": 404,
      "message": "Not Found"
    }
  },
  "statusCode": 500
}
```

The preferred way to get the statusCode is to use the [`resolveWithFullResponse` option](https://www.npmjs.com/package/request-promise#get-the-full-response-instead-of-just-the-body).